### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 authors = ["Lukas Geis <lukasgeis@gmx.de>"]
 license = "MIT"
 exclude = [".gitignore", "target"]
-homepage = "https://github.com/lukasgeis/bnb"
+repository = "https://github.com/lukasgeis/bnb"
 
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.